### PR TITLE
Phase 0: CI guardrails (block pins_studio) + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What changed
+
+## Why
+
+## How to test (Windows)
+
+## Changed files
+
+## Guardrails checklist
+- [ ] I did NOT modify `pins_studio/`
+- [ ] No secrets committed (.env, tokens, credentials)
+
+## UI Evidence Pack checklist
+*(ONLY if UI touched; otherwise write "N/A" and skip below)*
+- [ ] Home top (chips + ≥6 pins)
+- [ ] Home after scroll (loading/skeleton proof)
+- [ ] Pin detail (hero + Save/Open)
+- [ ] Save sheet open (boards + create input)
+- [ ] Mobile viewport (bottom nav + centered FAB)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  guardrails:
+    name: Phase 0 Guardrails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check legacy unchanged
+        run: node scripts/check-legacy-unchanged.js
+        env:
+          BEFORE: ${{ github.event.before }}

--- a/docs/PHASE0_GUARDRAILS.md
+++ b/docs/PHASE0_GUARDRAILS.md
@@ -1,0 +1,16 @@
+# Phase 0 Guardrails
+
+## Goal
+The `pins_studio/` directory is a legacy museum folder and must never change.
+
+## CI Enforcement
+Any PR or push that modifies, adds, deletes, or renames files within `pins_studio/**` will fail CI immediately.
+
+## Local Windows Command
+To verify compliance before pushing, run:
+```bash
+node scripts/check-legacy-unchanged.js --base origin/main --head HEAD
+```
+
+## Safety Note
+Do NOT run negative tests that create, delete, or rename `pins_studio/`. Never delete or rename it.

--- a/scripts/check-legacy-unchanged.js
+++ b/scripts/check-legacy-unchanged.js
@@ -1,0 +1,74 @@
+const { execSync } = require('child_process');
+
+let diffCommand = '';
+const args = process.argv.slice(2);
+let localBase = null;
+let localHead = null;
+
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--base' && args[i + 1]) {
+        localBase = args[i + 1];
+        i++;
+    } else if (args[i] === '--head' && args[i + 1]) {
+        localHead = args[i + 1];
+        i++;
+    }
+}
+
+if (localBase && localHead) {
+    diffCommand = `git diff --name-only "${localBase}...${localHead}"`;
+} else if (process.env.GITHUB_BASE_REF) {
+    diffCommand = `git diff --name-only "origin/${process.env.GITHUB_BASE_REF}...${process.env.GITHUB_SHA || 'HEAD'}"`;
+} else if (process.env.BEFORE) {
+    const before = process.env.BEFORE;
+    const head = process.env.GITHUB_SHA || 'HEAD';
+    if (before.match(/^0+$/) || !before) {
+        diffCommand = `git diff-tree --no-commit-id --name-only -r "${head}"`;
+    } else {
+        diffCommand = `git diff --name-only "${before}..${head}"`;
+    }
+} else {
+    console.error("❌ ERROR: --base and --head arguments required for local execution.");
+    process.exit(1);
+}
+
+try {
+    let changedFiles = [];
+
+    // 1) Committed diffs
+    try {
+        const diffOutput = execSync(diffCommand, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+        changedFiles.push(...diffOutput.split('\n').filter(Boolean));
+    } catch (e) {
+        // Ignore error if diff fails (e.g. branch doesn't exist locally yet)
+    }
+
+    // 2) Local working tree changes (staged/unstaged/untracked)
+    const statusOutput = execSync('git status --porcelain', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const statusLines = statusOutput.split('\n').filter(Boolean);
+    for (const line of statusLines) {
+        const filePath = line.substring(3).trim();
+        const cleanPath = filePath.replace(/^"(.*)"$/, '$1'); // Remove surrounding quotes if any
+        changedFiles.push(cleanPath);
+    }
+
+    // Remove duplicates
+    changedFiles = [...new Set(changedFiles)];
+
+    const forbiddenFiles = changedFiles.filter(file => {
+        const normalizedPath = file.replace(/\\/g, '/');
+        return normalizedPath.startsWith('pins_studio/');
+    });
+
+    if (forbiddenFiles.length > 0) {
+        console.error('❌ ERROR: FORBIDDEN CHANGES DETECTED.');
+        forbiddenFiles.forEach(f => console.error(`  - ${f}`));
+        process.exit(1);
+    } else {
+        console.log('✅ PASS: No forbidden legacy changes detected.');
+        process.exit(0);
+    }
+} catch (error) {
+    console.error('❌ ERROR: Failed to run git checks.');
+    process.exit(1);
+}


### PR DESCRIPTION
## What changed
- Added CI guardrail to fail PRs that modify pins_studio/
- Added PR template enforcing What/Why/How-to-test + UI evidence rules
- Added local+CI script to detect forbidden legacy changes
- Added concise Phase 0 guardrails doc

## Why
- pins_studio/ is a hard-forbidden legacy folder. CI enforcement prevents accidental edits and makes the rule non-negotiable.
- PR structure keeps phase discipline and makes changes reviewable.

## How to test (Windows)
- node scripts/check-legacy-unchanged.js --base origin/main --head HEAD
  Expected: ✅ PASS

## Changed files
- .github/workflows/ci.yml
- .github/pull_request_template.md
- scripts/check-legacy-unchanged.js
- docs/PHASE0_GUARDRAILS.md

## UI / Companion Evidence Pack
N/A (no UI touched)
