### PR TITLE
Phase 2: motion baseline + reduced motion

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^12.34.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -2676,6 +2677,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3076,6 +3104,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3943,6 +3986,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "framer-motion": "^12.34.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { createBrowserRouter, RouterProvider, Outlet, Link } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Outlet, Link, useLocation } from 'react-router-dom';
+import { AnimatePresence, motion } from 'framer-motion';
 import BottomNav from './components/BottomNav';
 import Page from './components/layout/Page';
 import Home from './pages/Home';
@@ -7,19 +8,36 @@ import Boards from './pages/Boards';
 import Profile from './pages/Profile';
 import Settings from './pages/Settings';
 import Admin from './pages/Admin';
+import { useReducedMotionPref } from './motion/useReducedMotionPref';
+import { getPageVariants } from './motion/variants';
 
 const AppShell = () => {
+  const location = useLocation();
+  const prefersReduced = useReducedMotionPref();
+  const pageVariants = getPageVariants(prefersReduced);
+
   return (
     <Page>
       {/* Dev links for Settings / Admin */}
-      <div className="bg-surface p-8 flex gap-16 border-b border-border">
+      <div className="bg-surface p-8 flex gap-16 border-b border-border relative z-50">
         <span className="font-semibold text-caption">Dev:</span>
         <Link to="/settings" className="hover:text-hover text-accent text-caption">Settings</Link>
         <Link to="/admin" className="hover:text-hover text-accent text-caption">Admin</Link>
       </div>
 
-      <main>
-        <Outlet />
+      <main className="relative">
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.div
+            key={location.pathname}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            variants={pageVariants}
+            className="w-full"
+          >
+            <Outlet />
+          </motion.div>
+        </AnimatePresence>
       </main>
 
       <BottomNav />

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,23 +1,45 @@
 import { Link, useLocation } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
 import Fab from './Fab';
+import { useReducedMotionPref } from '../motion/useReducedMotionPref';
+import { getActiveIndicatorVariants } from '../motion/variants';
 
 export default function BottomNav() {
     const location = useLocation();
+    const prefersReducedMotion = useReducedMotionPref();
+    const indicatorVariants = getActiveIndicatorVariants(prefersReducedMotion);
 
     const getLinkClass = (path: string) => {
         const isActive = location.pathname === path;
-        return `flex flex-col items-center justify-center w-full h-full text-caption font-medium transition-colors ${isActive ? 'text-text' : 'text-muted hover:text-text'
+        return `relative flex flex-col items-center justify-center w-full h-full text-caption font-medium transition-colors ${isActive ? 'text-text' : 'text-muted hover:text-text'
             }`;
     };
+
+    const renderActiveIndicator = (path: string) => (
+        <AnimatePresence>
+            {location.pathname === path && (
+                <motion.div
+                    layoutId="bottomNavIndicator"
+                    variants={indicatorVariants}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    className="absolute -top-[1px] w-32 h-[3px] bg-accent rounded-b-chip"
+                />
+            )}
+        </AnimatePresence>
+    );
 
     return (
         <nav className="fixed bottom-0 left-0 right-0 bg-surface border-t border-border h-64 flex items-center justify-around px-16 z-50">
             <Link to="/" className={getLinkClass('/')} aria-label="Home">
+                {renderActiveIndicator('/')}
                 <svg className="w-24 h-24 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
                 <span>Home</span>
             </Link>
 
             <Link to="/search" className={getLinkClass('/search')} aria-label="Search">
+                {renderActiveIndicator('/search')}
                 <svg className="w-24 h-24 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
                 <span>Search</span>
             </Link>
@@ -28,11 +50,13 @@ export default function BottomNav() {
             </div>
 
             <Link to="/boards" className={getLinkClass('/boards')} aria-label="Boards">
+                {renderActiveIndicator('/boards')}
                 <svg className="w-24 h-24 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path></svg>
                 <span>Boards</span>
             </Link>
 
             <Link to="/profile" className={getLinkClass('/profile')} aria-label="Profile">
+                {renderActiveIndicator('/profile')}
                 <svg className="w-24 h-24 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path></svg>
                 <span>Profile</span>
             </Link>

--- a/frontend/src/components/Fab.tsx
+++ b/frontend/src/components/Fab.tsx
@@ -1,12 +1,20 @@
+import { motion } from 'framer-motion';
+import { useReducedMotionPref } from '../motion/useReducedMotionPref';
+import { getFabPressVariants } from '../motion/variants';
+
 export default function Fab() {
+    const prefersReduced = useReducedMotionPref();
+    const pressVariants = getFabPressVariants(prefersReduced);
+
     return (
-        <button
-            className="absolute -top-24 left-1/2 transform -translate-x-1/2 bg-text hover:bg-hover text-surface rounded-chip p-16 shadow-sheet flex items-center justify-center transition-transform hover:scale-105 active:scale-95"
+        <motion.button
+            whileTap={pressVariants}
+            className="absolute -top-24 left-1/2 transform -translate-x-1/2 bg-text hover:bg-hover text-surface rounded-chip p-16 shadow-sheet flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-accent"
             aria-label="Create Placeholder"
         >
             <svg className="w-24 h-24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4"></path>
             </svg>
-        </button>
+        </motion.button>
     );
 }

--- a/frontend/src/motion/tokens.ts
+++ b/frontend/src/motion/tokens.ts
@@ -1,0 +1,18 @@
+/**
+ * Phase 2 centralized motion tokens.
+ * Values reflect the exact PRD requirements.
+ */
+export const MotionTokens = {
+    duration: {
+        fast: 0.16,      // 160ms
+        standard: 0.22,  // 220ms
+        emphasis: 0.28,  // 280ms
+    },
+    spring: {
+        sheet: {
+            type: 'spring',
+            stiffness: 380,
+            damping: 32,
+        }
+    }
+};

--- a/frontend/src/motion/useReducedMotionPref.ts
+++ b/frontend/src/motion/useReducedMotionPref.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns a boolean indicating whether the user has requested
+ * the system minimize the amount of non-essential motion.
+ */
+export function useReducedMotionPref() {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+        setPrefersReducedMotion(mediaQuery.matches);
+
+        const listener = (e: MediaQueryListEvent) => {
+            setPrefersReducedMotion(e.matches);
+        };
+
+        // React cleanly to system preference changes during usage
+        if (mediaQuery.addEventListener) {
+            mediaQuery.addEventListener('change', listener);
+        } else {
+            mediaQuery.addListener(listener);
+        }
+
+        return () => {
+            if (mediaQuery.removeEventListener) {
+                mediaQuery.removeEventListener('change', listener);
+            } else {
+                mediaQuery.removeListener(listener);
+            }
+        };
+    }, []);
+
+    return prefersReducedMotion;
+}

--- a/frontend/src/motion/variants.ts
+++ b/frontend/src/motion/variants.ts
@@ -1,0 +1,66 @@
+import { MotionTokens } from './tokens';
+
+/**
+ * Standard variants honoring prefers-reduced-motion.
+ */
+
+// 1) Page enter/exit transitions
+export const getPageVariants = (reducedMotion: boolean) => {
+    if (reducedMotion) {
+        return {
+            initial: { opacity: 0 },
+            animate: { opacity: 1, transition: { duration: 0.05 } },
+            exit: { opacity: 0, transition: { duration: 0.05 } }
+        };
+    }
+
+    return {
+        initial: { opacity: 0, y: 8 },
+        animate: {
+            opacity: 1,
+            y: 0,
+            transition: { duration: MotionTokens.duration.standard }
+        },
+        exit: {
+            opacity: 0,
+            y: -8,
+            transition: { duration: MotionTokens.duration.fast }
+        }
+    };
+};
+
+// 2) BottomNav Active Indicator
+export const getActiveIndicatorVariants = (reducedMotion: boolean) => {
+    if (reducedMotion) {
+        return {
+            initial: { opacity: 0 },
+            animate: { opacity: 1, transition: { duration: 0 } },
+            exit: { opacity: 0, transition: { duration: 0 } }
+        };
+    }
+
+    return {
+        initial: { scale: 0.8, opacity: 0 },
+        animate: {
+            scale: 1,
+            opacity: 1,
+            transition: { duration: MotionTokens.duration.fast }
+        },
+        exit: {
+            scale: 0.8,
+            opacity: 0,
+            transition: { duration: MotionTokens.duration.fast }
+        }
+    };
+};
+
+// 3) FAB Press Feedback
+export const getFabPressVariants = (reducedMotion: boolean) => {
+    if (reducedMotion) {
+        return {}; // No scale on tap
+    }
+    return {
+        scale: 0.98,
+        transition: { duration: MotionTokens.duration.fast }
+    };
+};


### PR DESCRIPTION
## What changed
- Added Framer Motion baseline + centralized motion tokens
- Added prefers-reduced-motion hook and motion variants
- Applied subtle transitions to routing, nav active state, and FAB press

## Why
- Motion communicates state and sets foundation for later sheets/detail transitions while remaining accessible

## How to test (Windows)
- cd frontend
- npm run dev (navigate Home -> Search; press FAB)
- Toggle reduced motion in OS settings; reload; confirm motion becomes minimal
- npm run build
- npm run preview (refresh /search)

## Companion Evidence
- A: Home -> Search transition
- B: FAB press feedback
- C: Reduced motion ON proof

## Guardrail
pins_studio/ untouched
