### PR TITLE
Phase 2: Sheet + Toast primitives

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider, Outlet, Link, useLocation } from '
 import { AnimatePresence, motion } from 'framer-motion';
 import BottomNav from './components/BottomNav';
 import Page from './components/layout/Page';
+import ToastContainer from './components/primitives/Toast';
 import Home from './pages/Home';
 import Search from './pages/Search';
 import Boards from './pages/Boards';
@@ -18,6 +19,7 @@ const AppShell = () => {
 
   return (
     <Page>
+      <ToastContainer />
       {/* Dev links for Settings / Admin */}
       <div className="bg-surface p-8 flex gap-16 border-b border-border relative z-50">
         <span className="font-semibold text-caption">Dev:</span>

--- a/frontend/src/components/primitives/Sheet.tsx
+++ b/frontend/src/components/primitives/Sheet.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useReducedMotionPref } from '../../motion/useReducedMotionPref';
+import { getSheetVariants, getBackdropVariants } from '../../motion/variants';
+
+interface SheetProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title?: string;
+    children: React.ReactNode;
+}
+
+export default function Sheet({ isOpen, onClose, title, children }: SheetProps) {
+    const prefersReduced = useReducedMotionPref();
+    const sheetVariants = getSheetVariants(prefersReduced);
+    const backdropVariants = getBackdropVariants(prefersReduced);
+
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+    const sheetRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            // 1) Save previous focus
+            previousFocusRef.current = document.activeElement as HTMLElement;
+
+            // 2) Lock body scroll
+            document.body.style.overflow = 'hidden';
+
+            // 3) Focus the sheet itself for ESC/a11y mechanics
+            // We need a small timeout to let the sheet mount in the DOM before focusing
+            const timeoutId = setTimeout(() => {
+                sheetRef.current?.focus();
+            }, 0);
+
+            return () => {
+                clearTimeout(timeoutId);
+                document.body.style.overflow = '';
+                previousFocusRef.current?.focus();
+            };
+        }
+    }, [isOpen]);
+
+    // ESC key handler
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (isOpen && e.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
+
+    // If we're not running in a browser environment with document body ready
+    if (typeof document === 'undefined') return null;
+
+    return createPortal(
+        <AnimatePresence>
+            {isOpen && (
+                <div className="fixed inset-0 z-[100] flex flex-col justify-end">
+                    {/* Backdrop (Blur + Dim) - tap to close */}
+                    <motion.div
+                        variants={backdropVariants}
+                        initial="initial"
+                        animate="animate"
+                        exit="exit"
+                        onClick={onClose}
+                        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+                        aria-hidden="true"
+                    />
+
+                    {/* Sheet Body */}
+                    <motion.div
+                        ref={sheetRef}
+                        // Add tabIndex -1 so it can programmatically take focus
+                        tabIndex={-1}
+                        variants={sheetVariants}
+                        initial="initial"
+                        animate="animate"
+                        exit="exit"
+                        className="relative w-full max-w-[1180px] mx-auto bg-surface rounded-t-sheet shadow-sheet outline-none focus:outline-none flex flex-col max-h-[90vh]"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby={title ? 'sheet-title' : undefined}
+                    >
+                        {/* Grabber indicator (visual only) */}
+                        <div className="flex justify-center pt-12 pb-8">
+                            <div className="w-48 h-[4px] bg-border rounded-chip" />
+                        </div>
+
+                        {/* Header (Optional via children/title, but generic close here if needed) */}
+                        {title && (
+                            <div className="px-16 md:px-24 pb-16 flex items-center justify-between border-b border-border">
+                                <h2 id="sheet-title" className="text-h2 font-h2 text-text m-0">{title}</h2>
+                                <button
+                                    onClick={onClose}
+                                    className="p-8 -mr-8 text-muted hover:text-text rounded-chip transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-accent"
+                                    aria-label="Close sheet"
+                                >
+                                    <svg className="w-24 h-24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+                                    </svg>
+                                </button>
+                            </div>
+                        )}
+
+                        {/* Scrollable Content Area */}
+                        <div className="px-16 md:px-24 py-24 overflow-y-auto overscroll-contain pb-64">
+                            {children}
+                        </div>
+                    </motion.div>
+                </div>
+            )}
+        </AnimatePresence>,
+        document.body
+    );
+}

--- a/frontend/src/components/primitives/Toast.tsx
+++ b/frontend/src/components/primitives/Toast.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { toastStore, type ToastConfig } from './toastStore';
+import { useReducedMotionPref } from '../../motion/useReducedMotionPref';
+import { getToastVariants } from '../../motion/variants';
+
+export default function ToastContainer() {
+    const [toasts, setToasts] = useState<ToastConfig[]>([]);
+    const prefersReduced = useReducedMotionPref();
+    const toastVariants = getToastVariants(prefersReduced);
+
+    useEffect(() => {
+        // Subscribe to store updates
+        const unsubscribe = toastStore.subscribe((newToasts) => {
+            setToasts([...newToasts]);
+        });
+        return unsubscribe;
+    }, []);
+
+    return (
+        <div
+            className="fixed bottom-[88px] left-1/2 transform -translate-x-1/2 flex flex-col items-center gap-12 z-[100] pointer-events-none"
+        // bottom-[88px] securely clears the 64px BottomNav + 24px gap per PRD
+        >
+            <AnimatePresence>
+                {toasts.map((t) => (
+                    <motion.div
+                        key={t.id}
+                        variants={toastVariants}
+                        initial="initial"
+                        animate="animate"
+                        exit="exit"
+                        layout="position"
+                        className={`
+              pointer-events-auto px-16 py-12 rounded-input shadow-sheet max-w-[90vw] md:max-w-md w-full
+              flex items-center text-button
+              ${t.type === 'error' ? 'bg-red-50 text-red-900 border border-red-200' :
+                                t.type === 'success' ? 'bg-green-50 text-green-900 border border-green-200' :
+                                    'bg-text text-surface'}
+            `}
+                    >
+                        <span>{t.message}</span>
+                        <button
+                            onClick={() => toastStore.remove(t.id)}
+                            className="ml-auto opacity-70 hover:opacity-100 p-4 -pr-4"
+                            aria-label="Dismiss"
+                        >
+                            <svg className="w-16 h-16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                        </button>
+                    </motion.div>
+                ))}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/frontend/src/components/primitives/toastStore.ts
+++ b/frontend/src/components/primitives/toastStore.ts
@@ -1,0 +1,63 @@
+// Store is independent of React
+
+export type ToastType = 'default' | 'success' | 'error';
+
+export interface ToastConfig {
+    id: string;
+    message: string;
+    type?: ToastType;
+    duration?: number;
+}
+
+type ToastListener = (toasts: ToastConfig[]) => void;
+
+class ToastStore {
+    private toasts: ToastConfig[] = [];
+    private listeners: Set<ToastListener> = new Set();
+    private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+
+    subscribe(listener: ToastListener) {
+        this.listeners.add(listener);
+        // initial state
+        listener(this.toasts);
+        return () => { this.listeners.delete(listener); };
+    }
+
+    private notify() {
+        this.listeners.forEach((l) => l(this.toasts));
+    }
+
+    add(toast: Omit<ToastConfig, 'id'>) {
+        const id = Date.now().toString() + Math.random().toString(36).slice(2, 6);
+        const newToast: ToastConfig = { ...toast, id };
+
+        // Only keep up to 3 toasts at a time
+        this.toasts = [...this.toasts, newToast].slice(-3);
+        this.notify();
+
+        const duration = toast.duration ?? 3000;
+        if (duration > 0) {
+            const timer = setTimeout(() => {
+                this.remove(id);
+            }, duration);
+            this.timers.set(id, timer);
+        }
+    }
+
+    remove(id: string) {
+        const timer = this.timers.get(id);
+        if (timer) {
+            clearTimeout(timer);
+            this.timers.delete(id);
+        }
+        this.toasts = this.toasts.filter((t) => t.id !== id);
+        this.notify();
+    }
+}
+
+export const toastStore = new ToastStore();
+
+// Expose direct trigger mechanism
+export const triggerToast = (config: Omit<ToastConfig, 'id'>) => {
+    toastStore.add(config);
+};

--- a/frontend/src/components/primitives/useToast.ts
+++ b/frontend/src/components/primitives/useToast.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { triggerToast, type ToastConfig } from './toastStore';
+
+export function useToast() {
+    const toast = useCallback(
+        (props: Omit<ToastConfig, 'id'> | string) => {
+            if (typeof props === 'string') {
+                triggerToast({ message: props, type: 'default', duration: 3000 });
+            } else {
+                triggerToast({
+                    message: props.message,
+                    type: props.type ?? 'default',
+                    duration: props.duration ?? 3000,
+                });
+            }
+        },
+        []
+    );
+
+    return { toast };
+}

--- a/frontend/src/motion/variants.ts
+++ b/frontend/src/motion/variants.ts
@@ -5,7 +5,7 @@ import { MotionTokens } from './tokens';
  */
 
 // 1) Page enter/exit transitions
-export const getPageVariants = (reducedMotion: boolean) => {
+export const getPageVariants = (reducedMotion: boolean): any => {
     if (reducedMotion) {
         return {
             initial: { opacity: 0 },
@@ -30,7 +30,7 @@ export const getPageVariants = (reducedMotion: boolean) => {
 };
 
 // 2) BottomNav Active Indicator
-export const getActiveIndicatorVariants = (reducedMotion: boolean) => {
+export const getActiveIndicatorVariants = (reducedMotion: boolean): any => {
     if (reducedMotion) {
         return {
             initial: { opacity: 0 },
@@ -55,12 +55,79 @@ export const getActiveIndicatorVariants = (reducedMotion: boolean) => {
 };
 
 // 3) FAB Press Feedback
-export const getFabPressVariants = (reducedMotion: boolean) => {
+export const getFabPressVariants = (reducedMotion: boolean): any => {
     if (reducedMotion) {
         return {}; // No scale on tap
     }
     return {
         scale: 0.98,
         transition: { duration: MotionTokens.duration.fast }
+    };
+};
+
+// 4) Bottom Sheet enter/exit transitions
+export const getSheetVariants = (reducedMotion: boolean): any => {
+    if (reducedMotion) {
+        return {
+            initial: { opacity: 0 },
+            animate: { opacity: 1, transition: { duration: MotionTokens.duration.fast } },
+            exit: { opacity: 0, transition: { duration: MotionTokens.duration.fast } }
+        };
+    }
+
+    return {
+        initial: { y: "100%", opacity: 0.5 },
+        animate: {
+            y: 0,
+            opacity: 1,
+            transition: MotionTokens.spring.sheet
+        },
+        exit: {
+            y: "100%",
+            opacity: 0,
+            transition: { duration: MotionTokens.duration.standard }
+        }
+    };
+};
+
+export const getBackdropVariants = (reducedMotion: boolean): any => {
+    if (reducedMotion) {
+        return {
+            initial: { opacity: 0 },
+            animate: { opacity: 1, transition: { duration: MotionTokens.duration.fast } },
+            exit: { opacity: 0, transition: { duration: MotionTokens.duration.fast } }
+        };
+    }
+    return {
+        initial: { opacity: 0 },
+        animate: { opacity: 1, transition: { duration: MotionTokens.duration.standard } },
+        exit: { opacity: 0, transition: { duration: MotionTokens.duration.standard } }
+    };
+};
+
+// 5) Toast enter/exit transitions
+export const getToastVariants = (reducedMotion: boolean): any => {
+    if (reducedMotion) {
+        return {
+            initial: { opacity: 0 },
+            animate: { opacity: 1, transition: { duration: MotionTokens.duration.fast } },
+            exit: { opacity: 0, transition: { duration: MotionTokens.duration.fast } }
+        };
+    }
+
+    return {
+        initial: { y: 20, opacity: 0, scale: 0.95 },
+        animate: {
+            y: 0,
+            opacity: 1,
+            scale: 1,
+            transition: { duration: MotionTokens.duration.fast }
+        },
+        exit: {
+            y: 20,
+            opacity: 0,
+            scale: 0.95,
+            transition: { duration: MotionTokens.duration.fast }
+        }
     };
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,14 +1,57 @@
+import { useState } from 'react';
 import { API_URL } from '../config/env';
 import Container from '../components/layout/Container';
+import Sheet from '../components/primitives/Sheet';
+import { useToast } from '../components/primitives/useToast';
 
 export default function Home() {
+    const [isSheetOpen, setSheetOpen] = useState(false);
+    const { toast } = useToast();
+
     return (
         <Container className="pt-24">
             <h1>Home</h1>
             <p className="text-muted mt-8 mb-16">Phase 2 UI foundation</p>
+
+            <div className="flex gap-12 mb-24">
+                <button
+                    onClick={() => setSheetOpen(true)}
+                    className="bg-accent text-surface px-16 py-8 rounded-full hover:bg-hover active:scale-95 transition-all text-button"
+                >
+                    Open Sheet
+                </button>
+                <button
+                    onClick={() => toast({ message: "Board created successfully!", type: "success" })}
+                    className="bg-surface text-text border border-border px-16 py-8 rounded-full hover:bg-bg active:scale-95 transition-all text-button"
+                >
+                    Show Toast
+                </button>
+            </div>
+
             <div className="font-mono bg-surface border border-border p-16 rounded-card">
                 API_URL = {API_URL}
             </div>
+
+            <Sheet
+                isOpen={isSheetOpen}
+                onClose={() => setSheetOpen(false)}
+                title="Demo Sheet"
+            >
+                <div className="space-y-16">
+                    <p className="text-body text-muted">
+                        This is a placeholder bottom sheet body. It locks background scroll, closes on ESC, and traps focus.
+                    </p>
+                    <div className="h-64 bg-bg rounded-card border border-border flex items-center justify-center text-muted">
+                        Placeholder content block
+                    </div>
+                    <button
+                        onClick={() => setSheetOpen(false)}
+                        className="w-full bg-border text-text py-12 rounded-full font-button hover:bg-muted/20 active:scale-95 transition-all"
+                    >
+                        Close
+                    </button>
+                </div>
+            </Sheet>
         </Container>
     );
 }


### PR DESCRIPTION
## What changed
- Added reusable Bottom Sheet primitive with blur backdrop + close behaviors
- Added toast system with auto-dismiss and reduced-motion support
- Added demo triggers on Home page (validation only)

## Why
- Phase 3+ Save flows and system feedback need stable primitives that respect tokens and accessibility

## How to test (Windows)
- cd frontend
- npm run dev
  - On Home: click Open Sheet, close via backdrop and ESC
  - Click Show Toast, verify auto-dismiss
  - Toggle reduced motion ON, reload, verify minimal animations
- npm run build
- npm run preview

## Companion Evidence
- A: Home (demo buttons)
- B: Sheet open (blur backdrop)
- C: Toast visible (and reduced motion note)

## Guardrail
pins_studio/ untouched
