### PR TITLE
Phase 2: core UI components (Button/Input/Chip)

### DIFF
--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
+import { cn } from '../../lib/cn';
+import { getFabPressVariants } from '../../motion/variants';
+import { useReducedMotionPref } from '../../motion/useReducedMotionPref';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: 'primary' | 'secondary' | 'ghost';
+    children: React.ReactNode;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ className, variant = 'primary', children, disabled, ...props }, ref) => {
+        const prefersReducedMotion = useReducedMotionPref();
+        const pressVariants = getFabPressVariants(prefersReducedMotion);
+
+        // Tokens based on pure Phase 2 design system
+        const baseStyles = "inline-flex items-center justify-center min-h-[44px] px-24 rounded-full font-button text-button transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-accent disabled:opacity-50 disabled:cursor-not-allowed";
+
+        const variants = {
+            primary: "bg-accent text-surface hover:bg-hover active:bg-hover shadow-sm",
+            secondary: "bg-surface border border-border text-text hover:bg-bg active:bg-border",
+            ghost: "bg-transparent text-accent hover:bg-accent/10 active:bg-accent/20"
+        };
+
+        return (
+            <motion.button
+                ref={ref}
+                whileTap={disabled ? undefined : pressVariants}
+                className={cn(baseStyles, variants[variant], className)}
+                disabled={disabled}
+                {...(props as HTMLMotionProps<"button">)}
+            >
+                {children}
+            </motion.button>
+        );
+    }
+);
+
+Button.displayName = 'Button';

--- a/frontend/src/components/core/Chip.tsx
+++ b/frontend/src/components/core/Chip.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
+import { cn } from '../../lib/cn';
+import { getFabPressVariants } from '../../motion/variants';
+import { useReducedMotionPref } from '../../motion/useReducedMotionPref';
+
+export interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    selected?: boolean;
+    size?: 'sm' | 'md'; // sm=32px, md=40px from spacing scale
+}
+
+export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
+    ({ className, selected = false, size = 'sm', disabled, children, ...props }, ref) => {
+        const prefersReducedMotion = useReducedMotionPref();
+        const pressVariants = getFabPressVariants(prefersReducedMotion);
+
+        const baseStyles = "inline-flex items-center justify-center rounded-full font-button text-caption transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-accent disabled:opacity-50 disabled:cursor-not-allowed border whitespace-nowrap";
+
+        const sizeStyles = {
+            sm: "h-32 px-16",
+            md: "h-40 px-20"
+        };
+
+        const stateStyles = selected
+            ? "bg-text text-surface border-text hover:opacity-90"
+            : "bg-surface text-text border-border hover:bg-bg";
+
+        return (
+            <motion.button
+                ref={ref}
+                whileTap={disabled ? undefined : pressVariants}
+                className={cn(baseStyles, sizeStyles[size], stateStyles, className)}
+                aria-pressed={selected}
+                disabled={disabled}
+                {...(props as HTMLMotionProps<"button">)}
+            >
+                {children}
+            </motion.button>
+        );
+    }
+);
+
+Chip.displayName = 'Chip';

--- a/frontend/src/components/core/Input.tsx
+++ b/frontend/src/components/core/Input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> { }
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+    ({ className, ...props }, ref) => {
+        return (
+            <input
+                ref={ref}
+                className={cn(
+                    "w-full min-h-[44px] px-16 rounded-input bg-surface text-text border border-border placeholder:text-muted focus:outline-none focus-visible:ring-4 focus-visible:ring-accent focus-visible:border-accent transition-all disabled:opacity-50 disabled:cursor-not-allowed text-body",
+                    className
+                )}
+                {...props}
+            />
+        );
+    }
+);
+
+Input.displayName = 'Input';

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]): string {
+    return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { API_URL } from '../config/env';
 import Container from '../components/layout/Container';
 import Sheet from '../components/primitives/Sheet';
 import { useToast } from '../components/primitives/useToast';
+import { Button } from '../components/core/Button';
 
 export default function Home() {
     const [isSheetOpen, setSheetOpen] = useState(false);
@@ -14,18 +15,18 @@ export default function Home() {
             <p className="text-muted mt-8 mb-16">Phase 2 UI foundation</p>
 
             <div className="flex gap-12 mb-24">
-                <button
+                <Button
                     onClick={() => setSheetOpen(true)}
-                    className="bg-accent text-surface px-16 py-8 rounded-full hover:bg-hover active:scale-95 transition-all text-button"
+                    variant="primary"
                 >
                     Open Sheet
-                </button>
-                <button
+                </Button>
+                <Button
                     onClick={() => toast({ message: "Board created successfully!", type: "success" })}
-                    className="bg-surface text-text border border-border px-16 py-8 rounded-full hover:bg-bg active:scale-95 transition-all text-button"
+                    variant="secondary"
                 >
                     Show Toast
-                </button>
+                </Button>
             </div>
 
             <div className="font-mono bg-surface border border-border p-16 rounded-card">

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,10 +1,31 @@
 import Container from '../components/layout/Container';
+import { Input } from '../components/core/Input';
+import { Chip } from '../components/core/Chip';
 
 export default function Search() {
     return (
-        <Container className="pt-24">
-            <h1>Search</h1>
-            <p className="text-muted mt-8">Phase 2 UI foundation</p>
+        <Container className="pt-24 space-y-24">
+            <div>
+                <h1>Search</h1>
+                <p className="text-muted mt-8">Phase 2 UI foundation</p>
+            </div>
+
+            {/* Simulated Search Input */}
+            <div className="relative max-w-md">
+                <Input placeholder="Search pins, boards, tags…" />
+                <svg className="absolute right-16 top-1/2 -translate-y-1/2 w-20 h-20 text-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                </svg>
+            </div>
+
+            {/* Simulated Filter Chips */}
+            <div className="flex flex-wrap gap-8">
+                <Chip selected size="md">For You</Chip>
+                <Chip size="md">UI/UX Patterns</Chip>
+                <Chip size="md">Marketing</Chip>
+                <Chip size="md">Design Tools</Chip>
+                <Chip size="md">Startups</Chip>
+            </div>
         </Container>
     );
 }


### PR DESCRIPTION
## What changed
- Added token-driven Button, Input, Chip components with 44px targets and focus-visible styles
- Updated Home/Search to use core components

## Why
- Prevents per-page styling drift and standardizes interaction affordances

## How to test (Windows)
- cd frontend
- npm run dev (Tab through controls; verify focus ring)
- npm run build
- npm run preview

## Companion Evidence
- A: Home (Buttons)
- B: Search (Input + Chips)
- C: Focus-visible proof (screenshot or note)

## Guardrail
pins_studio/ untouched
