### PR TITLE
Phase 3: mock feed seed pool + provider

### DIFF
--- a/frontend/src/data/mockFeed.ts
+++ b/frontend/src/data/mockFeed.ts
@@ -1,0 +1,23 @@
+import type { Pin } from '../types/pin';
+import { SEED_PINS } from './seedPins';
+
+export interface FeedPage {
+    items: Pin[];
+    nextCursor: number | null;
+}
+
+export const getPinsPage = async ({ cursor = 0, limit = 20 }: { cursor?: number; limit?: number }): Promise<FeedPage> => {
+    // Artificial delay to simulate network latency but not too slow (200ms)
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const start = cursor;
+    const end = start + limit;
+    const items = SEED_PINS.slice(start, end);
+
+    const nextCursor = end < SEED_PINS.length ? end : null;
+
+    return {
+        items,
+        nextCursor
+    };
+};

--- a/frontend/src/data/seedPins.ts
+++ b/frontend/src/data/seedPins.ts
@@ -1,0 +1,37 @@
+import type { Pin } from '../types/pin';
+
+// We use picsum.photos with a seed to get stable, deterministic placeholder images.
+// Width remains standard, height fluctuates to simulate masonry eventually (for Phase 3 prompt 2).
+const generateSeedData = (): Pin[] => {
+    const categories = ['UI', 'Marketing', 'Tools', 'Startups', 'Case Studies'];
+    const domains = ['dribbble.com', 'behance.net', 'github.com', 'producthunt.com', 'medium.com'];
+
+    const pins: Pin[] = [];
+
+    for (let i = 1; i <= 65; i++) {
+        const seed = `pin${i}`;
+        const category = categories[i % categories.length];
+        const domain = domains[i % domains.length];
+
+        // Vary heights predictably for future masonry validation
+        const height = 300 + ((i * 37) % 400);
+        const width = 400;
+
+        pins.push({
+            id: `mock-pin-${i}`,
+            title: `Placeholder Inspiration ${i} - ${category}`,
+            domain,
+            sourceUrl: `https://${domain}/design/${i}`,
+            canonicalUrl: `https://${domain}/design/${i}`,
+            imageUrl: `https://picsum.photos/seed/${seed}/${width}/${height}`,
+            imageWidth: width,
+            imageHeight: height,
+            category,
+            tags: ['design', category.toLowerCase(), 'inspiration']
+        });
+    }
+
+    return pins;
+};
+
+export const SEED_PINS: Pin[] = generateSeedData();

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,58 +1,60 @@
-import { useState } from 'react';
-import { API_URL } from '../config/env';
+import { useEffect, useState } from 'react';
 import Container from '../components/layout/Container';
-import Sheet from '../components/primitives/Sheet';
-import { useToast } from '../components/primitives/useToast';
-import { Button } from '../components/core/Button';
+import { Chip } from '../components/core/Chip';
+import { getPinsPage } from '../data/mockFeed';
+import type { Pin } from '../types/pin';
+
+const CATEGORIES = ['For You', 'UI', 'Marketing', 'Tools', 'Startups', 'Case Studies'];
 
 export default function Home() {
-    const [isSheetOpen, setSheetOpen] = useState(false);
-    const { toast } = useToast();
+    const [pins, setPins] = useState<Pin[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const loadInitialPins = async () => {
+            setIsLoading(true);
+            const data = await getPinsPage({ cursor: 0, limit: 20 });
+            setPins(data.items);
+            setIsLoading(false);
+        };
+        loadInitialPins();
+    }, []);
 
     return (
-        <Container className="pt-24">
-            <h1>Home</h1>
-            <p className="text-muted mt-8 mb-16">Phase 2 UI foundation</p>
-
-            <div className="flex gap-12 mb-24">
-                <Button
-                    onClick={() => setSheetOpen(true)}
-                    variant="primary"
-                >
-                    Open Sheet
-                </Button>
-                <Button
-                    onClick={() => toast({ message: "Board created successfully!", type: "success" })}
-                    variant="secondary"
-                >
-                    Show Toast
-                </Button>
+        <Container className="pt-24 pb-32">
+            {/* Filter Chips Row */}
+            <div className="flex gap-8 overflow-x-auto pb-16 no-scrollbar">
+                {CATEGORIES.map((cat, idx) => (
+                    <Chip key={cat} selected={idx === 0} size="md">
+                        {cat}
+                    </Chip>
+                ))}
             </div>
 
-            <div className="font-mono bg-surface border border-border p-16 rounded-card">
-                API_URL = {API_URL}
+            {/* Feed List (Non-Masonry Mock) */}
+            <div className="mt-16 flex flex-col gap-24">
+                {isLoading && pins.length === 0 ? (
+                    <div className="text-muted text-center py-48">Loading feed...</div>
+                ) : (
+                    pins.map((pin) => (
+                        <div key={pin.id} className="flex flex-col gap-8">
+                            {/* Fixed aspect ratio container for testing without masonry */}
+                            <div className="relative w-full aspect-[3/4] bg-bg rounded-card overflow-hidden border border-border">
+                                <img
+                                    src={pin.imageUrl}
+                                    alt={pin.title}
+                                    className="absolute inset-0 w-full h-full object-cover"
+                                    loading="lazy"
+                                />
+                            </div>
+                            <div className="px-4">
+                                <h3 className="text-body font-semibold text-text truncate">{pin.title}</h3>
+                                <p className="text-caption text-muted">{pin.domain}</p>
+                            </div>
+                        </div>
+                    ))
+                )}
             </div>
-
-            <Sheet
-                isOpen={isSheetOpen}
-                onClose={() => setSheetOpen(false)}
-                title="Demo Sheet"
-            >
-                <div className="space-y-16">
-                    <p className="text-body text-muted">
-                        This is a placeholder bottom sheet body. It locks background scroll, closes on ESC, and traps focus.
-                    </p>
-                    <div className="h-64 bg-bg rounded-card border border-border flex items-center justify-center text-muted">
-                        Placeholder content block
-                    </div>
-                    <button
-                        onClick={() => setSheetOpen(false)}
-                        className="w-full bg-border text-text py-12 rounded-full font-button hover:bg-muted/20 active:scale-95 transition-all"
-                    >
-                        Close
-                    </button>
-                </div>
-            </Sheet>
         </Container>
     );
 }

--- a/frontend/src/types/pin.ts
+++ b/frontend/src/types/pin.ts
@@ -1,0 +1,12 @@
+export interface Pin {
+    id: string;
+    title: string;
+    domain: string;
+    sourceUrl: string;
+    canonicalUrl: string;
+    imageUrl: string;
+    imageWidth?: number;
+    imageHeight?: number;
+    tags?: string[];
+    category?: string;
+}


### PR DESCRIPTION
## What changed
- Added Pin type + 60+ seeded mock pins
- Added cursor-paginated mock feed provider
- Updated Home to render seeded pins (non-masonry list for now)

## Why
- Feed must never look empty; establishes realistic data + pagination before masonry/infinite scroll

## How to test (Windows)
- cd frontend
- npm run dev (Home shows chips + pins)
- npm run build

## Companion Evidence
- A: Home top (chips + ≥6 pins)
- B: Home after scroll (more pins)

## Guardrail
pins_studio/ untouched
