### PR TITLE
Phase 3: masonry + skeletons + infinite scroll (mock)

### DIFF
--- a/frontend/src/components/feed/Masonry.tsx
+++ b/frontend/src/components/feed/Masonry.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+interface MasonryProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function Masonry({ children, className }: MasonryProps) {
+    return (
+        <div
+            className={cn(
+                // Mobile: 2 cols, Tablet: 3 cols, Desktop: 4 cols
+                // Gap natively handled by column-gap matching PRD (12px = gap-12)
+                "columns-2 md:columns-3 lg:columns-4 gap-12 w-full",
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+}

--- a/frontend/src/components/feed/PinCard.tsx
+++ b/frontend/src/components/feed/PinCard.tsx
@@ -1,0 +1,46 @@
+import type { Pin } from '../../types/pin';
+import { cn } from '../../lib/cn';
+
+interface PinCardProps {
+    pin: Pin;
+    className?: string;
+    onClick?: () => void;
+}
+
+export function PinCard({ pin, className, onClick }: PinCardProps) {
+    // We use the image height if available to prevent layout shifting
+    // Fallback to a 3/4 aspect ratio if unknown
+    const aspectRatio = pin.imageWidth && pin.imageHeight
+        ? `${pin.imageWidth} / ${pin.imageHeight}`
+        : '3 / 4';
+
+    return (
+        <div
+            className={cn(
+                "flex flex-col gap-8 group cursor-zoom-in break-inside-avoid mb-12",
+                className
+            )}
+            onClick={onClick}
+        >
+            <div
+                className="relative w-full bg-bg rounded-card overflow-hidden shadow-card"
+                style={{ aspectRatio }}
+            >
+                <img
+                    src={pin.imageUrl}
+                    alt={pin.title}
+                    className="absolute inset-0 w-full h-full object-cover group-hover:brightness-95 transition-all"
+                    loading="lazy"
+                />
+
+                {/* Hover overlay placeholder for future Save button */}
+                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors pointer-events-none" />
+            </div>
+
+            <div className="px-4 pb-4">
+                <h3 className="text-body font-semibold text-text truncate">{pin.title}</h3>
+                <p className="text-caption text-muted truncate">{pin.domain}</p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/feed/SkeletonCard.tsx
+++ b/frontend/src/components/feed/SkeletonCard.tsx
@@ -1,0 +1,23 @@
+import { cn } from '../../lib/cn';
+
+interface SkeletonCardProps {
+    className?: string;
+    // Let the parent dictate a random height to simulate masonry
+    // or default to standard aspect ratio
+    height?: number | string;
+}
+
+export function SkeletonCard({ className, height = 300 }: SkeletonCardProps) {
+    return (
+        <div className={cn("flex flex-col gap-8 break-inside-avoid mb-12", className)}>
+            <div
+                className="w-full bg-border rounded-card border border-border/50"
+                style={{ height }}
+            />
+            <div className="px-4 pb-4 space-y-4">
+                <div className="h-16 w-3/4 bg-border rounded-full" />
+                <div className="h-12 w-1/2 bg-bg rounded-full" />
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/hooks/useInfinitePins.ts
+++ b/frontend/src/hooks/useInfinitePins.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { Pin } from '../types/pin';
+import { getPinsPage } from '../data/mockFeed';
+
+interface UseInfinitePinsReturn {
+    pins: Pin[];
+    isLoadingInitial: boolean;
+    isFetchingMore: boolean;
+    hasNextPage: boolean;
+    loadMore: () => Promise<void>;
+}
+
+export function useInfinitePins(): UseInfinitePinsReturn {
+    const [pins, setPins] = useState<Pin[]>([]);
+    const [cursor, setCursor] = useState<number | null>(0);
+    const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+    const [isFetchingMore, setIsFetchingMore] = useState(false);
+
+    // Guard against strict mode double-firing
+    const isFetchingRef = useRef(false);
+
+    // Restore scroll state hook
+    useEffect(() => {
+        const savedScrollPos = sessionStorage.getItem('feedScrollY');
+        if (savedScrollPos) {
+            // Small timeout to allow basic layout shift processing before scroll restoration
+            const id = setTimeout(() => {
+                window.scrollTo(0, parseInt(savedScrollPos, 10));
+            }, 50);
+            return () => clearTimeout(id);
+        }
+    }, []);
+
+    // Save scroll state hook
+    useEffect(() => {
+        const handleScroll = () => {
+            sessionStorage.setItem('feedScrollY', window.scrollY.toString());
+        };
+        window.addEventListener('scroll', handleScroll, { passive: true });
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    // Initial load effect
+    useEffect(() => {
+        const loadInitial = async () => {
+            if (isFetchingRef.current) return;
+            isFetchingRef.current = true;
+            setIsLoadingInitial(true);
+
+            const data = await getPinsPage({ cursor: 0, limit: 20 });
+            setPins(data.items);
+            setCursor(data.nextCursor);
+
+            setIsLoadingInitial(false);
+            isFetchingRef.current = false;
+        };
+
+        if (pins.length === 0) {
+            loadInitial();
+        }
+    }, [pins.length]);
+
+    const loadMore = useCallback(async () => {
+        if (cursor === null || isFetchingRef.current) return;
+
+        isFetchingRef.current = true;
+        setIsFetchingMore(true);
+
+        try {
+            const data = await getPinsPage({ cursor, limit: 20 });
+
+            setPins(prev => {
+                // Deduplicate pins just in case
+                const existingIds = new Set(prev.map(p => p.id));
+                const newPins = data.items.filter(p => !existingIds.has(p.id));
+                return [...prev, ...newPins];
+            });
+
+            setCursor(data.nextCursor);
+        } finally {
+            setIsFetchingMore(false);
+            isFetchingRef.current = false;
+        }
+    }, [cursor]);
+
+    return {
+        pins,
+        isLoadingInitial,
+        isFetchingMore,
+        hasNextPage: cursor !== null,
+        loadMore
+    };
+}


### PR DESCRIPTION
## What changed
- Added PinCard + Masonry components
- Added static SkeletonCard placeholders
- Implemented infinite scroll (IntersectionObserver + cursor pagination) using mock provider only
- Added basic scroll position restore

## Why
- Makes feed feel real with 60+ pins and continuous loading without backend calls

## How to test (Windows)
- cd frontend
- npm run dev (scroll to trigger loads; observe skeletons)
- npm run build
- npm run preview

## Companion Evidence
- A: Home top (masonry)
- B: Loading state with skeletons mid-scroll
- C: After next page loaded

## Guardrail
pins_studio/ untouched
