### PR TITLE
Phase 3: save-to-board sheet (mock)

### DIFF
--- a/frontend/src/components/boards/SaveToBoardSheet.tsx
+++ b/frontend/src/components/boards/SaveToBoardSheet.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect } from 'react';
+import Sheet from '../primitives/Sheet';
+import { Button } from '../core/Button';
+import { Input } from '../core/Input';
+import { useBoards } from '../../hooks/useBoards';
+import { useToast } from '../primitives/useToast';
+import { cn } from '../../lib/cn';
+
+interface SaveToBoardSheetProps {
+    isOpen: boolean;
+    onClose: () => void;
+    pinId: string;
+}
+
+export function SaveToBoardSheet({ isOpen, onClose, pinId }: SaveToBoardSheetProps) {
+    const { boards, createBoard, savePin, getSuggestedBoard } = useBoards();
+    const { toast } = useToast();
+
+    const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
+    const [newBoardName, setNewBoardName] = useState('');
+
+    const suggestedBoard = getSuggestedBoard();
+
+    // Reset state on open
+    useEffect(() => {
+        if (isOpen) {
+            setNewBoardName('');
+            const suggested = getSuggestedBoard();
+            setSelectedBoardId(suggested ? suggested.id : null);
+        }
+    }, [isOpen, getSuggestedBoard]);
+
+    const handleSave = () => {
+        if (!selectedBoardId) return;
+        const board = boards.find(b => b.id === selectedBoardId);
+        if (board) {
+            savePin(pinId, board.id);
+            toast({ message: `Saved to ${board.name}`, type: 'success' });
+            onClose();
+        }
+    };
+
+    const handleCreateAndSave = () => {
+        const { board, isNew } = createBoard(newBoardName);
+        if (board) {
+            if (isNew) {
+                toast({ message: 'Board created', type: 'success' }); // Required PRD copy
+            }
+            savePin(pinId, board.id);
+            // Delay the second toast slightly to avoid React batching visual jank, or stack them
+            setTimeout(() => {
+                toast({ message: `Saved to ${board.name}`, type: 'success' });
+            }, 100);
+
+            onClose();
+        }
+    };
+
+    const trimmedInput = newBoardName.trim();
+    const isCreateValid = trimmedInput.length >= 1 && trimmedInput.length <= 32;
+
+    return (
+        <Sheet isOpen={isOpen} onClose={onClose} title="Save to board">
+            <div className="flex flex-col gap-24">
+                {/* Suggested Board */}
+                {suggestedBoard && (
+                    <div className="flex flex-col gap-8">
+                        <span className="text-caption font-semibold text-muted">Suggested</span>
+                        <button
+                            onClick={() => setSelectedBoardId(suggestedBoard.id)}
+                            className={cn(
+                                "flex items-center justify-between p-12 rounded-card text-left transition-colors",
+                                selectedBoardId === suggestedBoard.id
+                                    ? "bg-accent/10 border border-accent/20"
+                                    : "bg-surface border border-border hover:bg-bg"
+                            )}
+                        >
+                            <span className="text-body font-semibold text-text truncate">
+                                Suggested: {suggestedBoard.name}
+                            </span>
+                            {selectedBoardId === suggestedBoard.id && (
+                                <svg className="w-20 h-20 text-accent flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                                </svg>
+                            )}
+                        </button>
+                    </div>
+                )}
+
+                {/* All Boards List */}
+                <div className="flex flex-col gap-8">
+                    <span className="text-caption font-semibold text-muted">All Boards</span>
+                    <div className="flex flex-col gap-8 max-h-[30vh] overflow-y-auto no-scrollbar pr-4">
+                        {boards.map(board => {
+                            // Don't duplicate if it's already suggested
+                            return (
+                                <button
+                                    key={board.id}
+                                    onClick={() => setSelectedBoardId(board.id)}
+                                    className={cn(
+                                        "flex items-center justify-between p-12 rounded-card text-left transition-colors",
+                                        selectedBoardId === board.id
+                                            ? "bg-accent/10 border border-accent/20"
+                                            : "bg-surface border border-border hover:bg-bg"
+                                    )}
+                                >
+                                    <span className="text-body font-semibold text-text truncate">
+                                        {board.name}
+                                    </span>
+                                    {selectedBoardId === board.id && (
+                                        <svg className="w-20 h-20 text-accent flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                                        </svg>
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    <Button
+                        variant="primary"
+                        onClick={handleSave}
+                        disabled={!selectedBoardId}
+                        className="mt-8"
+                    >
+                        Save
+                    </Button>
+                </div>
+
+                <div className="w-full h-[1px] bg-border my-8" />
+
+                {/* Inline Create Row */}
+                <div className="flex flex-col gap-12">
+                    <span className="text-caption font-semibold text-muted">Create board</span>
+                    <div className="flex items-center gap-12">
+                        <div className="flex-grow">
+                            <Input
+                                placeholder="Create new board…"
+                                value={newBoardName}
+                                onChange={(e) => setNewBoardName(e.target.value)}
+                                maxLength={32}
+                            />
+                        </div>
+                        <Button
+                            variant="secondary"
+                            disabled={!isCreateValid}
+                            onClick={handleCreateAndSave}
+                            className="flex-shrink-0"
+                        >
+                            Create & Save
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </Sheet>
+    );
+}

--- a/frontend/src/data/mockBoards.ts
+++ b/frontend/src/data/mockBoards.ts
@@ -1,0 +1,9 @@
+import type { Board } from '../types/board';
+
+export const MOCK_BOARDS: Board[] = [
+    { id: 'board-mock-1', name: 'UI Inspiration', createdAt: Date.now() - 1000000 },
+    { id: 'board-mock-2', name: 'Typography', createdAt: Date.now() - 800000 },
+    { id: 'board-mock-3', name: 'Brand Identity', createdAt: Date.now() - 600000 },
+    { id: 'board-mock-4', name: 'Motion Design', createdAt: Date.now() - 400000 },
+    { id: 'board-mock-5', name: 'Productivity Tools', createdAt: Date.now() - 200000 },
+];

--- a/frontend/src/hooks/useBoards.ts
+++ b/frontend/src/hooks/useBoards.ts
@@ -1,0 +1,40 @@
+import { useSyncExternalStore, useCallback } from 'react';
+import { boardsStore } from '../state/boardsStore';
+import type { Board } from '../types/board';
+
+export function useBoards() {
+    const boards = useSyncExternalStore(
+        boardsStore.subscribe.bind(boardsStore),
+        () => boardsStore.getBoards()
+    );
+
+    const createBoard = useCallback((name: string) => {
+        return boardsStore.createBoard(name);
+    }, []);
+
+    const savePin = useCallback((pinId: string, boardId: string) => {
+        boardsStore.savePinToBoard(pinId, boardId);
+    }, []);
+
+    const getSavedBoardId = useCallback((pinId: string) => {
+        return boardsStore.getSavedBoardId(pinId);
+    }, []);
+
+    const getSuggestedBoard = useCallback((): Board | null => {
+        if (boards.length === 0) return null;
+
+        const uiInspo = boards.find(b => b.name === 'UI Inspiration');
+        if (uiInspo) return uiInspo;
+
+        // Fallback to most recently created
+        return [...boards].sort((a, b) => b.createdAt - a.createdAt)[0];
+    }, [boards]);
+
+    return {
+        boards,
+        createBoard,
+        savePin,
+        getSavedBoardId,
+        getSuggestedBoard
+    };
+}

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -5,16 +5,16 @@ import { getPinById } from '../data/getPinById';
 import type { Pin } from '../types/pin';
 import { useReducedMotionPref } from '../motion/useReducedMotionPref';
 import { Button } from '../components/core/Button';
-import { useToast } from '../components/primitives/useToast';
 import Container from '../components/layout/Container';
+import { SaveToBoardSheet } from '../components/boards/SaveToBoardSheet';
 
 export default function PinDetail() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const prefersReduced = useReducedMotionPref();
-    const { toast } = useToast();
 
     const [pin, setPin] = useState<Pin | null>(null);
+    const [isSaveSheetOpen, setIsSaveSheetOpen] = useState(false);
 
     useEffect(() => {
         if (id) {
@@ -66,7 +66,7 @@ export default function PinDetail() {
                                 <Button variant="secondary" onClick={() => window.open(pin.sourceUrl, '_blank')}>
                                     Open
                                 </Button>
-                                <Button variant="primary" onClick={() => toast({ message: "Saved!", type: "success" })}>
+                                <Button variant="primary" onClick={() => setIsSaveSheetOpen(true)}>
                                     Save
                                 </Button>
                             </div>
@@ -74,6 +74,12 @@ export default function PinDetail() {
                     </div>
                 </div>
             </div>
+
+            <SaveToBoardSheet
+                isOpen={isSaveSheetOpen}
+                onClose={() => setIsSaveSheetOpen(false)}
+                pinId={pin.id}
+            />
         </Container>
     );
 }

--- a/frontend/src/state/boardsStore.ts
+++ b/frontend/src/state/boardsStore.ts
@@ -1,0 +1,51 @@
+import type { Board } from '../types/board';
+import { MOCK_BOARDS } from '../data/mockBoards';
+
+class BoardsStore {
+    private boards: Board[] = [...MOCK_BOARDS];
+    // Map of pinId -> boardId
+    private savedPins: Record<string, string> = {};
+    private listeners: Set<() => void> = new Set();
+
+    subscribe(listener: () => void) {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    private notify() {
+        this.listeners.forEach(l => l());
+    }
+
+    getBoards() {
+        return this.boards;
+    }
+
+    getSavedBoardId(pinId: string) {
+        return this.savedPins[pinId] || null;
+    }
+
+    createBoard(name: string): { board: Board | null; isNew: boolean } {
+        const trimmed = name.trim();
+        if (trimmed.length < 1 || trimmed.length > 32) return { board: null, isNew: false };
+
+        const existing = this.boards.find(b => b.name.toLowerCase() === trimmed.toLowerCase());
+        if (existing) return { board: existing, isNew: false }; // Dedupe
+
+        const newBoard: Board = {
+            id: `board-${Date.now()}`,
+            name: trimmed,
+            createdAt: Date.now()
+        };
+        // Add to front so it shows up at the top
+        this.boards = [newBoard, ...this.boards];
+        this.notify();
+        return { board: newBoard, isNew: true };
+    }
+
+    savePinToBoard(pinId: string, boardId: string) {
+        this.savedPins[pinId] = boardId;
+        this.notify();
+    }
+}
+
+export const boardsStore = new BoardsStore();

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -1,0 +1,5 @@
+export interface Board {
+    id: string;
+    name: string;
+    createdAt: number;
+}


### PR DESCRIPTION
## What changed
- Added local mock boards store + hooks
- Added SaveToBoardSheet (suggested board + inline create)
- Wired Pin Detail Save button to sheet
- Toasts for Save and Create

## Why
- One-tap Save flow is core UX; mock state proves UI/logic before backend wiring

## How to test (Windows)
- cd frontend
- npm run dev
  - Open /pin/:id
  - Click Save -> sheet opens
  - Save to suggested board -> toast 'Saved to UI Inspiration'
  - Create & Save -> 'Board created' then 'Saved to {BoardName}'
- npm run build
- npm run preview

## Companion Evidence
- A: Pin detail
- B: Save sheet open
- C: Saved toast (and optional Create&Save)

## Guardrail
pins_studio/ untouched
