### PR TITLE
Phase 4: Boards CRUD + pin assignment

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { PinsModule } from './pins/pins.module';
+import { BoardsModule } from './boards/boards.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule, BoardsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/boards/boards.controller.ts
+++ b/backend/src/boards/boards.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpCode, HttpStatus, ValidationPipe } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { CreateBoardDto } from './dto/create-board.dto';
+import { UpdateBoardDto } from './dto/update-board.dto';
+import { BoardParamsDto, BoardPinParamsDto, BoardsQueryDto } from './dto/board.params';
+
+@Controller('boards')
+export class BoardsController {
+    constructor(private readonly boardsService: BoardsService) { }
+
+    @Post()
+    @HttpCode(HttpStatus.CREATED)
+    create(@Body(new ValidationPipe({ whitelist: true })) createBoardDto: CreateBoardDto) {
+        return this.boardsService.create(createBoardDto);
+    }
+
+    @Get()
+    findAll(@Query(new ValidationPipe({ transform: true })) query: BoardsQueryDto) {
+        return this.boardsService.findAll(query.userId);
+    }
+
+    @Get(':id')
+    findOne(@Param(new ValidationPipe({ whitelist: true })) params: BoardParamsDto) {
+        return this.boardsService.findOne(params.id);
+    }
+
+    @Patch(':id')
+    update(
+        @Param(new ValidationPipe({ whitelist: true })) params: BoardParamsDto,
+        @Body(new ValidationPipe({ whitelist: true })) updateBoardDto: UpdateBoardDto,
+    ) {
+        return this.boardsService.update(params.id, updateBoardDto);
+    }
+
+    @Delete(':id')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    remove(@Param(new ValidationPipe({ whitelist: true })) params: BoardParamsDto) {
+        return this.boardsService.remove(params.id);
+    }
+
+    @Post(':id/pins/:pinId')
+    assignPin(@Param(new ValidationPipe({ whitelist: true })) params: BoardPinParamsDto) {
+        return this.boardsService.assignPin(params.id, params.pinId);
+    }
+
+    @Delete(':id/pins/:pinId')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    unassignPin(@Param(new ValidationPipe({ whitelist: true })) params: BoardPinParamsDto) {
+        return this.boardsService.unassignPin(params.id, params.pinId);
+    }
+}

--- a/backend/src/boards/boards.module.ts
+++ b/backend/src/boards/boards.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { BoardsController } from './boards.controller';
+
+@Module({
+    controllers: [BoardsController],
+    providers: [BoardsService],
+    exports: [BoardsService],
+})
+export class BoardsModule { }

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateBoardDto } from './dto/create-board.dto';
+import { UpdateBoardDto } from './dto/update-board.dto';
+import { mapPrismaError } from '../common/prisma-errors';
+
+@Injectable()
+export class BoardsService {
+    constructor(private prisma: PrismaService) { }
+
+    async create(createBoardDto: CreateBoardDto) {
+        try {
+            return await this.prisma.board.create({
+                data: createBoardDto,
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async findAll(userId?: string) {
+        try {
+            const whereClause = userId ? { userId } : {};
+            return await this.prisma.board.findMany({
+                where: whereClause,
+                orderBy: { createdAt: 'desc' },
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async findOne(id: string) {
+        try {
+            const board = await this.prisma.board.findUnique({
+                where: { id },
+            });
+            if (!board) {
+                throw new NotFoundException('Record not found');
+            }
+            return board;
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async update(id: string, updateBoardDto: UpdateBoardDto) {
+        try {
+            return await this.prisma.board.update({
+                where: { id },
+                data: updateBoardDto,
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async remove(id: string) {
+        try {
+            return await this.prisma.board.delete({
+                where: { id },
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async assignPin(boardId: string, pinId: string) {
+        try {
+            // Validate board exists
+            const board = await this.prisma.board.findUnique({ where: { id: boardId } });
+            if (!board) throw new NotFoundException('Board not found');
+
+            // Validate pin exists and update its boardId mapping
+            return await this.prisma.pin.update({
+                where: { id: pinId },
+                data: { boardId },
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async unassignPin(boardId: string, pinId: string) {
+        try {
+            // Validate board and pin relation directly using findFirst or findUnique
+            const pin = await this.prisma.pin.findUnique({ where: { id: pinId } });
+            if (!pin) throw new NotFoundException('Pin not found');
+            if (!boardId) throw new NotFoundException('Board not found'); // Should have already validated param id formats
+
+            if (pin.boardId !== boardId) {
+                throw new ConflictException('pin not assigned to board');
+            }
+
+            await this.prisma.pin.update({
+                where: { id: pinId },
+                data: { boardId: null },
+            });
+            return;
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+}

--- a/backend/src/boards/dto/board.params.ts
+++ b/backend/src/boards/dto/board.params.ts
@@ -1,0 +1,20 @@
+import { IsUUID, IsOptional } from 'class-validator';
+
+export class BoardParamsDto {
+    @IsUUID(4, { message: 'Invalid board UUID format' })
+    id: string;
+}
+
+export class BoardPinParamsDto {
+    @IsUUID(4, { message: 'Invalid board UUID format' })
+    id: string;
+
+    @IsUUID(4, { message: 'Invalid pin UUID format' })
+    pinId: string;
+}
+
+export class BoardsQueryDto {
+    @IsOptional()
+    @IsUUID(4, { message: 'Invalid userId UUID format' })
+    userId?: string;
+}

--- a/backend/src/boards/dto/create-board.dto.ts
+++ b/backend/src/boards/dto/create-board.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MaxLength, IsUUID } from 'class-validator';
+
+export class CreateBoardDto {
+    @IsString()
+    @MaxLength(64)
+    name: string;
+
+    @IsUUID()
+    userId: string; // TEMP until Phase 6
+}

--- a/backend/src/boards/dto/update-board.dto.ts
+++ b/backend/src/boards/dto/update-board.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateBoardDto } from './create-board.dto';
+import { OmitType } from '@nestjs/mapped-types';
+
+// UpdateBoardDto typically only updates the name, we shouldn't allow changing the userId owner
+export class UpdateBoardDto extends PartialType(OmitType(CreateBoardDto, ['userId'] as const)) { }


### PR DESCRIPTION
## What changed
- Added Boards CRUD endpoints with DTO validation
- Added endpoints to assign/unassign pins to boards

## Why
- Backend groundwork for Save-to-board and Boards screens integration later

## How to test (Windows)
- cd backend
- npm run start:dev
- POST/GET/PATCH/DELETE /boards
- POST /boards/:id/pins/:pinId and DELETE /boards/:id/pins/:pinId

## Guardrail
pins_studio/ untouched
