### PR TITLE
Docs: fix nextCursor example format

### DIFF
--- a/docs/API_CONTRACT_PHASE4.md
+++ b/docs/API_CONTRACT_PHASE4.md
@@ -47,7 +47,7 @@ Retrieves a cursor-paginated feed of Pins. Offers stable ordering via `createdAt
       "updatedAt": "2026-02-28T15:51:10.912Z"
     }
   ],
-  "nextCursor": "eyAgIC... base64...  x234"
+  "nextCursor": "<base64CursorString>"
 }
 ```
 


### PR DESCRIPTION
## What changed
- Updated nextCursor example to be a proper placeholder/base64 string

## Why
- Keeps contract examples realistic and copy-paste friendly

## How to test
- N/A (docs only)

## Guardrail
pins_studio/ untouched
