### PR TITLE
Phase 5: packs foundation (packs + items + ingest stub)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,10 @@ import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { PinsModule } from './pins/pins.module';
 import { BoardsModule } from './boards/boards.module';
+import { PacksModule } from './packs/packs.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule, BoardsModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule, BoardsModule, PacksModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/packs/dto/add-pack-items.dto.ts
+++ b/backend/src/packs/dto/add-pack-items.dto.ts
@@ -1,0 +1,20 @@
+import { IsUrl, IsOptional, ValidateNested, ArrayMaxSize, ArrayMinSize, IsArray } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PackItemDto {
+    @IsUrl()
+    sourceUrl: string;
+
+    @IsOptional()
+    @IsUrl()
+    canonicalUrl?: string; // Optional for now
+}
+
+export class AddPackItemsDto {
+    @IsArray()
+    @ArrayMinSize(1)
+    @ArrayMaxSize(500)
+    @ValidateNested({ each: true })
+    @Type(() => PackItemDto)
+    items: PackItemDto[];
+}

--- a/backend/src/packs/dto/create-pack.dto.ts
+++ b/backend/src/packs/dto/create-pack.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, MaxLength, MinLength, Matches, IsOptional } from 'class-validator';
+
+export class CreatePackDto {
+    @IsString()
+    @MinLength(1)
+    @MaxLength(80)
+    name: string;
+
+    @IsString()
+    @MinLength(3)
+    @MaxLength(40)
+    @Matches(/^[a-z0-9-]+$/, {
+        message: 'Slug must consist of lowercase letters, numbers, and hyphens only',
+    })
+    slug: string;
+
+    @IsOptional()
+    @IsString()
+    description?: string;
+}

--- a/backend/src/packs/dto/pack.params.ts
+++ b/backend/src/packs/dto/pack.params.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class PackParamsDto {
+    @IsUUID(4, { message: 'Invalid pack UUID format' })
+    id: string;
+}

--- a/backend/src/packs/dto/pack.query.ts
+++ b/backend/src/packs/dto/pack.query.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { PackItemStatus } from '@prisma/client';
+
+export class PackQueryDto {
+    @IsOptional()
+    @IsEnum(PackItemStatus, { message: 'status must be pending, ingested, or failed' })
+    status?: PackItemStatus;
+}

--- a/backend/src/packs/packs.controller.ts
+++ b/backend/src/packs/packs.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Post, Body, Param, Query, HttpCode, HttpStatus, ValidationPipe, NotImplementedException } from '@nestjs/common';
+import { PacksService } from './packs.service';
+import { CreatePackDto } from './dto/create-pack.dto';
+import { AddPackItemsDto } from './dto/add-pack-items.dto';
+import { PackParamsDto } from './dto/pack.params';
+import { PackQueryDto } from './dto/pack.query';
+
+@Controller('packs')
+export class PacksController {
+    constructor(private readonly packsService: PacksService) { }
+
+    @Post()
+    @HttpCode(HttpStatus.CREATED)
+    create(@Body(new ValidationPipe({ whitelist: true })) createPackDto: CreatePackDto) {
+        // TODO: Phase 6 Admin Auth guard here
+        return this.packsService.create(createPackDto);
+    }
+
+    @Get()
+    findAll() {
+        return this.packsService.findAll();
+    }
+
+    @Post(':id/items')
+    @HttpCode(HttpStatus.CREATED)
+    addItems(
+        @Param(new ValidationPipe({ whitelist: true })) params: PackParamsDto,
+        @Body(new ValidationPipe({ whitelist: true })) addPackItemsDto: AddPackItemsDto
+    ) {
+        // TODO: Phase 6 Admin Auth guard here
+        return this.packsService.addItems(params.id, addPackItemsDto);
+    }
+
+    @Get(':id/items')
+    findItems(
+        @Param(new ValidationPipe({ whitelist: true })) params: PackParamsDto,
+        @Query(new ValidationPipe({ transform: true })) query: PackQueryDto
+    ) {
+        return this.packsService.findItems(params.id, query.status);
+    }
+}
+
+@Controller('jobs')
+export class JobsController {
+    @Post('ingest-pack/:id')
+    @HttpCode(HttpStatus.NOT_IMPLEMENTED)
+    ingestPack(@Param(new ValidationPipe({ whitelist: true })) params: PackParamsDto) {
+        // TODO: Phase 6 Admin Auth guard here
+        throw new NotImplementedException('Ingestion pipeline wired in Phase 5 Prompt 2/3');
+    }
+}

--- a/backend/src/packs/packs.module.ts
+++ b/backend/src/packs/packs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PacksService } from './packs.service';
+import { PacksController, JobsController } from './packs.controller';
+
+@Module({
+    controllers: [PacksController, JobsController],
+    providers: [PacksService],
+    exports: [PacksService],
+})
+export class PacksModule { }

--- a/backend/src/packs/packs.service.ts
+++ b/backend/src/packs/packs.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePackDto } from './dto/create-pack.dto';
+import { AddPackItemsDto } from './dto/add-pack-items.dto';
+import { mapPrismaError } from '../common/prisma-errors';
+import { PackItemStatus } from '@prisma/client';
+
+@Injectable()
+export class PacksService {
+    constructor(private prisma: PrismaService) { }
+
+    async create(createPackDto: CreatePackDto) {
+        try {
+            return await this.prisma.curatedPack.create({
+                data: createPackDto,
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async findAll() {
+        try {
+            return await this.prisma.curatedPack.findMany({
+                orderBy: { createdAt: 'desc' },
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async addItems(packId: string, addPackItemsDto: AddPackItemsDto) {
+        try {
+            // Validate pack exists
+            const pack = await this.prisma.curatedPack.findUnique({ where: { id: packId } });
+            if (!pack) throw new NotFoundException('Pack not found');
+
+            // Fetch existing items for this pack to avoid duplicates (sourceUrl OR canonicalUrl)
+            const existingItems = await this.prisma.curatedPackItem.findMany({
+                where: { packId },
+                select: { sourceUrl: true, canonicalUrl: true }
+            });
+
+            const existingSources = new Set(existingItems.map(i => i.sourceUrl));
+            const existingCanonicals = new Set(existingItems.map(i => i.canonicalUrl));
+
+            let created = 0;
+            let skipped = 0;
+
+            const newItems: { packId: string; sourceUrl: string; canonicalUrl: string }[] = [];
+
+            for (const item of addPackItemsDto.items) {
+                const canonical = item.canonicalUrl || item.sourceUrl; // Default canonicalUrl to sourceUrl if not provided
+                if (existingSources.has(item.sourceUrl) || existingCanonicals.has(canonical)) {
+                    skipped++;
+                } else {
+                    newItems.push({
+                        packId,
+                        sourceUrl: item.sourceUrl,
+                        canonicalUrl: canonical,
+                    });
+                    existingSources.add(item.sourceUrl);
+                    existingCanonicals.add(canonical);
+                }
+            }
+
+            if (newItems.length > 0) {
+                const result = await this.prisma.curatedPackItem.createMany({
+                    data: newItems,
+                    skipDuplicates: true,
+                });
+                created = result.count;
+            }
+
+            return { created, skipped };
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+
+    async findItems(packId: string, status?: PackItemStatus) {
+        try {
+            const pack = await this.prisma.curatedPack.findUnique({ where: { id: packId } });
+            if (!pack) throw new NotFoundException('Pack not found');
+
+            const whereClause: any = { packId };
+            if (status) {
+                whereClause.status = status;
+            }
+
+            return await this.prisma.curatedPackItem.findMany({
+                where: whereClause,
+                orderBy: { createdAt: 'desc' },
+            });
+        } catch (error) {
+            mapPrismaError(error);
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- Added CuratedPack + CuratedPackItem endpoints
- Added ingest-pack endpoint stub (pipeline added in next prompt)

## Why
- Establishes admin seeding structure for 1000+ pins ingestion

## How to test (Windows)
- cd backend
- npm run start:dev
- POST /packs
- POST /packs/:id/items
- GET /packs/:id/items?status=pending
- POST /jobs/ingest-pack/:id (stub)

## Guardrail
pins_studio/ untouched
