### PR TITLE
Phase 5: ingestion pipeline (OG + canonicalize + dedupe)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^6.19.2",
+        "cheerio": "^1.2.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "reflect-metadata": "^0.2.2",
@@ -4258,6 +4259,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4535,6 +4542,48 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -4958,6 +5007,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5094,6 +5171,61 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -5218,6 +5350,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
@@ -5230,6 +5387,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -6358,6 +6527,37 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -8105,6 +8305,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -8316,6 +8528,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -10020,6 +10281,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -10220,6 +10490,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.19.2",
+    "cheerio": "^1.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "reflect-metadata": "^0.2.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,9 +6,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { PinsModule } from './pins/pins.module';
 import { BoardsModule } from './boards/boards.module';
 import { PacksModule } from './packs/packs.module';
+import { JobsModule } from './jobs/jobs.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule, BoardsModule, PacksModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, PinsModule, BoardsModule, PacksModule, JobsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/ingestion/og/og.fetch.ts
+++ b/backend/src/ingestion/og/og.fetch.ts
@@ -1,0 +1,74 @@
+import * as https from 'https';
+import * as http from 'http';
+
+export interface FetchResult {
+    html: string;
+    url: string; // The final resolved URL after redirects
+    error?: string;
+    status?: number;
+}
+
+export async function fetchHtmlSafely(url: string, timeoutMs = 8000, maxSizeBytes = 2 * 1024 * 1024): Promise<FetchResult> {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(url, {
+            signal: controller.signal,
+            headers: {
+                'User-Agent': 'PinsStudioBot/1.0 (+http://pins.studio)',
+                'Accept': 'text/html,application/xhtml+xml',
+            },
+            redirect: 'follow', // Fetch API follows up to 20 redirects natively by default, which is safe enough
+        });
+
+        clearTimeout(id);
+
+        if (!response.ok) {
+            return { html: '', url: response.url, error: `HTTP ${response.status}`, status: response.status };
+        }
+
+        const contentType = response.headers.get('content-type');
+        if (contentType && !contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+            return { html: '', url: response.url, error: `Invalid content type: ${contentType}` };
+        }
+
+        // Read stream safely bounded by max size
+        const reader = response.body?.getReader();
+        if (!reader) {
+            return { html: '', url: response.url, error: 'No response body' };
+        }
+
+        let receivedLength = 0;
+        const chunks: Uint8Array[] = [];
+
+        while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) break;
+
+            if (value) {
+                receivedLength += value.length;
+                chunks.push(value);
+
+                if (receivedLength > maxSizeBytes) {
+                    reader.cancel();
+                    return { html: '', url: response.url, error: 'Response exceeded maximum allowed size' };
+                }
+            }
+        }
+
+        // Combine chunks
+        const htmlBuffer = Buffer.concat(chunks);
+        const htmlString = htmlBuffer.toString('utf-8');
+
+        return { html: htmlString, url: response.url, status: response.status };
+
+    } catch (error: any) {
+        clearTimeout(id);
+        if (error.name === 'AbortError') {
+            return { html: '', url, error: 'Request timed out' };
+        }
+        return { html: '', url, error: error.message || 'Unknown network error' };
+    }
+}

--- a/backend/src/ingestion/og/og.parse.ts
+++ b/backend/src/ingestion/og/og.parse.ts
@@ -1,0 +1,64 @@
+import * as cheerio from 'cheerio';
+import { OgMetadata } from './og.types';
+
+export function parseOgMetadata(html: string, urlStr: string): OgMetadata {
+    const $ = cheerio.load(html);
+
+    // Helper to get meta tag content
+    const getMeta = (property: string, name: string) => {
+        return (
+            $(`meta[property="${property}"]`).attr('content') ||
+            $(`meta[name="${name}"]`).attr('content') ||
+            null
+        );
+    };
+
+    // Determine actual hostname from the resolved URL
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(urlStr);
+    } catch (e) {
+        parsedUrl = new URL('https://unknown.com');
+    }
+
+    // 1. Extract Title: og:title > <title> > hostname
+    let title = getMeta('og:title', 'title');
+    if (!title) {
+        title = $('title').first().text();
+    }
+    if (!title || title.trim() === '') {
+        title = parsedUrl.hostname.replace(/^www\./, '');
+    }
+
+    // 2. Extract Description: og:description > meta name="description"
+    const description = getMeta('og:description', 'description');
+
+    // 3. Extract Image: og:image (first)
+    let image = getMeta('og:image', 'image');
+
+    // Make image URL absolute if it is relative
+    if (image && !image.startsWith('http') && !image.startsWith('https')) {
+        try {
+            const imgUrl = new URL(image, parsedUrl.href);
+            image = imgUrl.href;
+        } catch (e) {
+            image = null; // Unresolvable
+        }
+    }
+
+    // 4. Domain (from canonicalUrl/inputUrl hostname, no www)
+    const domain = parsedUrl.hostname.toLowerCase().replace(/^www\./, '');
+
+    return {
+        title: title.trim(),
+        description: description ? description.trim() : null,
+        image: image ? image.trim() : null,
+        domain,
+    };
+}
+
+export function extractCanonicalFromHtml(html: string): string | null {
+    const $ = cheerio.load(html);
+    const canonicalHref = $('link[rel="canonical"]').attr('href');
+    return canonicalHref || null;
+}

--- a/backend/src/ingestion/og/og.types.ts
+++ b/backend/src/ingestion/og/og.types.ts
@@ -1,0 +1,14 @@
+export interface OgMetadata {
+    title: string | null;
+    description: string | null;
+    image: string | null;
+    domain: string;
+}
+
+export interface IngestionResult {
+    sourceUrl: string;
+    canonicalUrl: string;
+    metadata?: OgMetadata;
+    error?: string;
+    isDuplicate?: boolean;
+}

--- a/backend/src/ingestion/url/canonicalize.ts
+++ b/backend/src/ingestion/url/canonicalize.ts
@@ -1,0 +1,69 @@
+import { stripTracking } from './stripTracking';
+
+/**
+ * Canonicalizes a URL based on robust rules.
+ * @param sourceUrl The original URL string
+ * @param canonicalFromHtml The literal href from <link rel="canonical"> tag if present
+ * @returns Decided canonical string, or null if parse totally fails
+ */
+export function canonicalizeUrl(sourceUrl: string, canonicalFromHtml?: string | null): string | null {
+    try {
+        let base = new URL(sourceUrl);
+
+        // If scheme is missing (e.g., //example.com), force https
+        if (base.protocol !== 'http:' && base.protocol !== 'https:') {
+            base = new URL('https://' + sourceUrl);
+        }
+
+        let target = base;
+
+        // Evaluate canonicalTag if present
+        if (canonicalFromHtml) {
+            try {
+                const canonical = new URL(canonicalFromHtml, base.href); // Resolves relative links against base
+
+                // Simple heuristic: if the domains match exactly, or canonical is www equivalent
+                // we trust it. Strip 'www.' to compare core domains
+                const baseDomain = base.hostname.replace(/^www\./, '');
+                const canDomain = canonical.hostname.replace(/^www\./, '');
+
+                if (baseDomain === canDomain) {
+                    target = canonical;
+                }
+            } catch (e) {
+                // invalid canonical URL, stick to base
+            }
+        }
+
+        // Normalize
+        target.hostname = target.hostname.toLowerCase();
+
+        // Remove default ports
+        if (target.port === '80' && target.protocol === 'http:') target.port = '';
+        if (target.port === '443' && target.protocol === 'https:') target.port = '';
+
+        // Strip tracking parameters
+        stripTracking(target);
+
+        // Sort search parameters for deterministic URL string
+        target.searchParams.sort();
+
+        // Construct final string
+        let finalStr = target.href;
+
+        // Remove trailing slash if it has no path other than root
+        // To match PRD "remove trailing slash (except root)", actually we want path '/' to stay '/' if empty,
+        // but if it's `/foo/`, it becomes `/foo` unless it's just `https://example.com/`.
+        // Wait, the prompt says "remove trailing slash (except root)".
+        // A URL object will format `https://example.com` as `https://example.com/` which is the root.
+        // If we have `https://example.com/foo/`, we strip it.
+        if (target.pathname !== '/' && target.pathname.endsWith('/')) {
+            target.pathname = target.pathname.slice(0, -1);
+            finalStr = target.href;
+        }
+
+        return finalStr;
+    } catch (error) {
+        return null; // parse totally failed
+    }
+}

--- a/backend/src/ingestion/url/stripTracking.ts
+++ b/backend/src/ingestion/url/stripTracking.ts
@@ -1,0 +1,35 @@
+/**
+ * List of common tracking parameters to strip from URLs
+ * to ensure cleaner canonical URLs.
+ */
+const trackingParams = new Set([
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'gclid',
+    'fbclid',
+    'msclkid',
+    'igshid',
+    'mc_cid',
+    'mc_eid',
+    '_hsenc',
+    '_hsmi',
+    'zanpid',
+]);
+
+/**
+ * Removes known tracking parameters from a URL object in-place.
+ * @param url URL object to modify
+ */
+export function stripTracking(url: URL): void {
+    const keysToDelete: string[] = [];
+    url.searchParams.forEach((value, key) => {
+        if (trackingParams.has(key.toLowerCase())) {
+            keysToDelete.push(key);
+        }
+    });
+
+    keysToDelete.forEach(key => url.searchParams.delete(key));
+}

--- a/backend/src/jobs/jobs.controller.ts
+++ b/backend/src/jobs/jobs.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post, Param, ValidationPipe } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+import { PackParamsDto } from '../packs/dto/pack.params';
+
+@Controller('jobs')
+export class JobsController {
+    constructor(private readonly jobsService: JobsService) { }
+
+    @Post('ingest-pack/:id')
+    async ingestPack(@Param(new ValidationPipe({ whitelist: true })) params: PackParamsDto) {
+        // TODO: Phase 6 Admin Auth guard here
+        return this.jobsService.ingestPack(params.id);
+    }
+}

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+import { JobsController } from './jobs.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+    imports: [PrismaModule],
+    controllers: [JobsController],
+    providers: [JobsService],
+    exports: [JobsService],
+})
+export class JobsModule { }

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { fetchHtmlSafely } from '../ingestion/og/og.fetch';
+import { extractCanonicalFromHtml, parseOgMetadata } from '../ingestion/og/og.parse';
+import { canonicalizeUrl } from '../ingestion/url/canonicalize';
+import { PackItemStatus } from '@prisma/client';
+
+@Injectable()
+export class JobsService {
+    private readonly logger = new Logger(JobsService.name);
+
+    constructor(private readonly prisma: PrismaService) { }
+
+    async ingestPack(packId: string, limit = 200) {
+        // Validate pack exists
+        const pack = await this.prisma.curatedPack.findUnique({ where: { id: packId } });
+        if (!pack) throw new NotFoundException('Pack not found');
+
+        // Get pending items
+        const items = await this.prisma.curatedPackItem.findMany({
+            where: {
+                packId,
+                status: PackItemStatus.pending,
+            },
+            take: limit,
+            orderBy: { createdAt: 'asc' },
+        });
+
+        const summary = {
+            packId,
+            processed: 0,
+            ingested: 0,
+            failed: 0,
+            deduped: 0,
+            errors: [] as { itemId: string; error: string }[],
+        };
+
+        if (items.length === 0) {
+            return summary;
+        }
+
+        // Since this is Prompt 2, we process sequentially to avoid overwhelming rate limits
+        for (const item of items) {
+            summary.processed++;
+
+            try {
+                // 1. Fetch HTML safely
+                const fetchResult = await fetchHtmlSafely(item.sourceUrl);
+
+                if (fetchResult.error || !fetchResult.html) {
+                    throw new Error(fetchResult.error || 'Empty HTML returned');
+                }
+
+                // 2. Extract Canonical link element from HTML if present
+                const canonicalFromHtml = extractCanonicalFromHtml(fetchResult.html);
+
+                // 3. Robust Canonicalization
+                // Use the final resolved URL from fetchResult if there are redirects, as base
+                const finalUrl = canonicalizeUrl(fetchResult.url || item.sourceUrl, canonicalFromHtml);
+
+                if (!finalUrl) {
+                    throw new Error('canonicalize_failed_invalid_url');
+                }
+
+                // 4. Parse OG Metadata
+                const ogMetadata = parseOgMetadata(fetchResult.html, finalUrl);
+
+                // Update the item strictly to lock in the computed canonicalUrl
+                await this.prisma.curatedPackItem.update({
+                    where: { id: item.id },
+                    data: { canonicalUrl: finalUrl },
+                });
+
+                // 5. Attempt creation in DB (dedupe handling via Prisma Catch)
+                // If image is null/empty we store an empty string or placeholder for Prompt 3 repair
+                const finalImage = ogMetadata.image || '';
+
+                try {
+                    // Temporarily hardcode a system userId if needed, or query first admin.
+                    // The PRD says "no auth yet, create placeholder userId handling".
+                    // We'll just grab the first user in DB to act as the ingest owner
+                    const adminUser = await this.prisma.user.findFirst();
+                    if (!adminUser) throw new Error('system_user_missing');
+
+                    await this.prisma.pin.create({
+                        data: {
+                            title: ogMetadata.title || 'Untitled',
+                            description: ogMetadata.description,
+                            sourceUrl: item.sourceUrl,
+                            canonicalUrl: finalUrl,
+                            domain: ogMetadata.domain,
+                            imageUrl: finalImage,
+                            userId: adminUser.id,
+                        },
+                    });
+
+                    // Mark item ingested
+                    await this.prisma.curatedPackItem.update({
+                        where: { id: item.id },
+                        data: {
+                            status: PackItemStatus.ingested,
+                            lastError: null,
+                        },
+                    });
+
+                    summary.ingested++;
+
+                } catch (dbError: any) {
+                    if (dbError.code === 'P2002') {
+                        // Unique constraint violation -> treated as deduped successfully
+                        await this.prisma.curatedPackItem.update({
+                            where: { id: item.id },
+                            data: {
+                                status: PackItemStatus.ingested,
+                                lastError: 'duplicate_canonical',
+                            },
+                        });
+                        summary.deduped++;
+                        summary.ingested++; // Count duplicate as successfully resolved
+                    } else {
+                        throw dbError; // Bubble unexpected DB errors
+                    }
+                }
+
+            } catch (itemError: any) {
+                summary.failed++;
+                const errorMessage = itemError.message || 'unknown_error';
+                summary.errors.push({ itemId: item.id, error: errorMessage });
+
+                // Mark failed
+                await this.prisma.curatedPackItem.update({
+                    where: { id: item.id },
+                    data: {
+                        status: PackItemStatus.failed,
+                        lastError: String(errorMessage).slice(0, 255),
+                    },
+                });
+            }
+        }
+
+        return summary;
+    }
+}

--- a/backend/src/packs/packs.controller.ts
+++ b/backend/src/packs/packs.controller.ts
@@ -39,13 +39,3 @@ export class PacksController {
         return this.packsService.findItems(params.id, query.status);
     }
 }
-
-@Controller('jobs')
-export class JobsController {
-    @Post('ingest-pack/:id')
-    @HttpCode(HttpStatus.NOT_IMPLEMENTED)
-    ingestPack(@Param(new ValidationPipe({ whitelist: true })) params: PackParamsDto) {
-        // TODO: Phase 6 Admin Auth guard here
-        throw new NotImplementedException('Ingestion pipeline wired in Phase 5 Prompt 2/3');
-    }
-}

--- a/backend/src/packs/packs.module.ts
+++ b/backend/src/packs/packs.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { PacksService } from './packs.service';
-import { PacksController, JobsController } from './packs.controller';
+import { PacksController } from './packs.controller';
 
 @Module({
-    controllers: [PacksController, JobsController],
+    controllers: [PacksController],
     providers: [PacksService],
     exports: [PacksService],
 })


### PR DESCRIPTION
## What changed
- Implemented /jobs/ingest-pack/:id ingestion pipeline (sync)
- Added URL canonicalization + tracking param stripping
- Added OG metadata parsing and robust error handling
- Dedupe handled via unique canonicalUrl
- Refactored `jobs.controller.ts` into a standalone module

## Why
- Enables reliable seeding from curated packs to reach 1000+ pins without duplicates

## How to test (Windows)
- Create pack + items
- POST /jobs/ingest-pack/:id
- GET /pins?limit=5 to confirm pin creation

## Guardrail
pins_studio/ untouched
