### PR TITLE
Docs: add GCS env vars + setup notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-VITE_API_URL=http://localhost:4000
-DATABASE_URL="postgresql://user:password@localhost:5432/mydb?schema=public"
-PEXELS_API_KEY="your_pexels_api_key_here"
-REDIS_URL="redis://localhost:6379"
-INGEST_ENABLED="true"
+# Frontend (Vite)
+VITE_API_URL="http://localhost:4000"
+
+# Backend env lives in backend/.env (copy from backend/.env.example)
+# GCS vars are used by backend only (reserved for future GCS storage integration):
+GCS_PROJECT_ID="your-gcs-project-id"
+GCS_BUCKET="your-gcs-bucket-name"
+GOOGLE_APPLICATION_CREDENTIALS="backend/credentials/gcs-sa.json"

--- a/docs/PHASE1_LOCAL_DEV.md
+++ b/docs/PHASE1_LOCAL_DEV.md
@@ -32,3 +32,9 @@ Copy `.env.example` to `.env` in the root of the project. Do NOT commit the `.en
 ```bash
 cp .env.example .env
 ```
+
+Backend env (DB/Redis/GCS/etc):
+```bash
+cp backend/.env.example backend/.env
+```
+Do NOT commit `backend/.env`.

--- a/docs/PHASE5_INGESTION_OPS.md
+++ b/docs/PHASE5_INGESTION_OPS.md
@@ -13,6 +13,9 @@
 | `INGEST_ENABLED` | ✅ | Set to `"true"` to enable ingestion endpoints |
 | `PEXELS_API_KEY` | ✅ | Pexels API key for image fallback |
 | `WORKER_MODE` | Worker only | Set to `"true"` when running the worker process |
+| `GCS_PROJECT_ID` | ✅ | Google Cloud project ID |
+| `GCS_BUCKET` | ✅ | GCS bucket name for image storage |
+| `GOOGLE_APPLICATION_CREDENTIALS` | ✅ | Path to GCS service-account JSON |
 
 ## Architecture
 
@@ -107,3 +110,11 @@ Invoke-RestMethod -Uri http://localhost:4000/pins?limit=20
 - No secrets are logged or committed
 - `GET /pins` service (`pins.service.ts`) imports **zero** ingestion modules
 - Worker logs `[INGEST external fetch]` for every external call (traceable)
+
+## GCS Credentials
+
+> [!CAUTION]
+> GCS service account JSON must be local-only and gitignored (`backend/credentials/*`).
+> Never commit credential files to the repository.
+
+GCS vars are reserved for future image storage integration; current ingestion stores `imageUrl`/`attributionText` in DB.


### PR DESCRIPTION
## What changed
- Added GCS vars to root .env.example (backend-only, reserved)
- Updated Phase 5 ops doc with GCS env rows + credentials caution
- Updated Phase 1 local dev doc with backend env copy instructions

## Why
- Keeps docs aligned with current GCS plan and prevents credential commits

## How to test
- N/A (docs only)

## Guardrail
pins_studio/ untouched