### PR TITLE
Phase 6: closeout (auth/admin QA + docs)

### DIFF
--- a/docs/API_CONTRACT_PHASE4.md
+++ b/docs/API_CONTRACT_PHASE4.md
@@ -222,3 +222,39 @@ Returns the status of a BullMQ job.
 ```
 
 > **Note**: Ingestion runs externally in worker process only. `GET /pins` is DB-only — no external calls.
+
+---
+
+## Phase 6: Authentication & Admin
+
+### `POST /auth/dev-login`
+(Dev only) Login with email and name without password.
+**Response**: `201 Created` (Sets `ps_access` and `ps_refresh` cookies)
+
+### `POST /auth/register`
+Register with email, password, and optional name.
+**Response**: `201 Created` (Sets `ps_access` and `ps_refresh` cookies)
+
+### `POST /auth/login`
+Login with email and password.
+**Response**: `201 Created` (Sets `ps_access` and `ps_refresh` cookies)
+
+### `POST /auth/refresh`
+Rotate access and refresh cookies.
+**Response**: `201 Created` (Sets new `ps_access` and `ps_refresh` cookies)
+
+### `POST /auth/logout`
+Log out user.
+**Response**: `201 Created` (Clears `ps_access` and `ps_refresh` cookies)
+
+### `GET /auth/me`
+Retrieve currently logged-in user profile.
+**Response**: `200 OK`
+
+### `GET /auth/google`
+Initiate Google OAuth flow.
+**Response**: `302 Found` (Redirects to Google)
+
+### `GET /auth/google/callback`
+Google OAuth callback endpoint.
+**Response**: `302 Found` (Redirects to frontend `APP_URL`, sets cookies)

--- a/docs/PHASE6_AUTH_ADMIN.md
+++ b/docs/PHASE6_AUTH_ADMIN.md
@@ -1,0 +1,51 @@
+# Phase 6: Authentication and Admin Enforcement
+
+## Environment Variables
+- `AUTH_DEV_LOGIN`: Toggles `/auth/dev-login` endpoint
+- `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET`: Secrets for signing JWT cookies
+- `BCRYPT_ROUNDS`: Int salt rounds for password hashes
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`: Google OAuth credentials
+- `ADMIN_EMAILS`: Comma-separated allowlist of admin emails
+- `ADMIN_PANEL_ENABLED`: Toggles the `/admin` AdminJS UI
+- `ADMIN_PANEL_EMAIL`, `ADMIN_PANEL_PASSWORD`: Basic auth credentials for `/admin`
+- `ADMIN_COOKIE_PASSWORD`: Secret for AdminJS session cookie `adminjs`
+
+## Cookie Mechanics
+Authentications are maintained strictly through `HttpOnly`, `SameSite=Lax` cookies to prevent XSS. 
+- `ps_access`: Short-lived JWT (e.g. 15m).
+- `ps_refresh`: Long-lived JWT (e.g. 7d) used solely at `/auth/refresh` to rotate tokens.
+
+## Endpoints List
+- `POST /auth/dev-login`: Bootstrap login for DEV testing.
+- `POST /auth/register`: Create account with email & password.
+- `POST /auth/login`: Authenticate with email & password.
+- `POST /auth/refresh`: Use `ps_refresh` cookie to rotate sessions.
+- `GET /auth/google`: Trigger Google OAuth 2.0 flow.
+- `GET /auth/google/callback`: Map Google profile, upsert user, and Set-Cookie.
+- `GET /auth/me`: Resolve profile using `ps_access`.
+- `POST /auth/logout`: Clear cookies and kill session.
+
+## Admin Enforcement
+- **API Roles**: The `ADMIN_EMAILS` env list determines whether a user acquires `role="admin"` upon login. The `AdminRoleGuard` leverages `ps_access` JWT to enforce admin-only restrictions on endpoints like `POST /packs`, `POST /packs/:id/items`, and `POST /jobs/ingest-pack/:id`.
+- **AdminJS UI**: Managed completely separately under `/admin`, protected via `ADMIN_PANEL_EMAIL` & `ADMIN_PANEL_PASSWORD` to isolate DB-management UI from standard backend RBAC.
+
+## Testing Locally (CURL snippets)
+*Run with `npm run start:dev` and replace placeholder inputs/passwords as necessary.*
+
+### Standard Auth
+```sh
+# Register
+curl -i -c cookies.txt -b cookies.txt -X POST http://localhost:4000/auth/register -H "Content-Type: application/json" -d "{\"email\":\"user@test.com\",\"password\":\"TestPass123!\",\"name\":\"User\"}"
+
+# Login
+curl -i -c cookies.txt -b cookies.txt -X POST http://localhost:4000/auth/login -H "Content-Type: application/json" -d "{\"email\":\"user@test.com\",\"password\":\"TestPass123!\"}"
+
+# Me
+curl -i -c cookies.txt -b cookies.txt http://localhost:4000/auth/me
+
+# Refresh
+curl -i -c cookies.txt -b cookies.txt -X POST http://localhost:4000/auth/refresh
+
+# Logout
+curl -i -c cookies.txt -b cookies.txt -X POST http://localhost:4000/auth/logout
+```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider, Outlet, Link, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useState, useEffect } from 'react';
 import BottomNav from './components/BottomNav';
 import Page from './components/layout/Page';
 import ToastContainer from './components/primitives/Toast';
@@ -19,14 +20,32 @@ const AppShell = () => {
   const prefersReduced = useReducedMotionPref();
   const pageVariants = getPageVariants(prefersReduced);
 
+  const [session, setSession] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_URL}/auth/me`, { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (data && data.email) {
+          setSession(data.email);
+        }
+      })
+      .catch(() => { });
+  }, []);
+
   return (
     <Page>
       <ToastContainer />
       {/* Dev links for Settings / Admin */}
-      <div className="bg-surface p-8 flex gap-16 border-b border-border relative z-50">
-        <span className="font-semibold text-caption">Dev:</span>
-        <Link to="/settings" className="hover:text-hover text-accent text-caption">Settings</Link>
-        <Link to="/admin" className="hover:text-hover text-accent text-caption">Admin</Link>
+      <div className="bg-surface p-8 flex gap-16 border-b border-border relative z-50 items-center justify-between">
+        <div className="flex gap-16 items-center">
+          <span className="font-semibold text-caption">Dev:</span>
+          <Link to="/settings" className="hover:text-hover text-accent text-caption">Settings</Link>
+          <Link to="/admin" className="hover:text-hover text-accent text-caption">Admin</Link>
+        </div>
+        <div className="text-caption text-secondary">
+          {session ? `Signed in as ${session}` : 'Not signed in'}
+        </div>
       </div>
 
       <main className="relative">


### PR DESCRIPTION
## What changed
- Added Phase 6 auth/admin documentation
- Verified Phase 6 gates (auth flows + admin enforcement + rate limits)
- Minimal FE session indicator

## Why
- Locks Phase 6 deliverables and provides a stable reference for future phases

## How to test (Windows)
- Follow docs/PHASE6_AUTH_ADMIN.md

## Guardrail
pins_studio/ untouched